### PR TITLE
ci: Remove Python3.8 newest tests.

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -23,8 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        config: [ {python: '3.8', dependencies: 'newest'},
-                  {python: '3.9', dependencies: 'newest'},
+        config: [ {python: '3.9', dependencies: 'newest'},
                   {python: '3.10', dependencies: 'newest'},
                   {python: '3.11', dependencies: 'newest'},
                   {python: '3.11', dependencies: 'minimal'},


### PR DESCRIPTION
## Description
Removes python3.8-newest from the test suite.

## Motivation and Context
Newest versions of NumPy no longer support Python 3.8.
<!-- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/synced_collections/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/synced_collections/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/synced_collections/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/synced_collections/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
