### PR TITLE
Apply numpy 2 migrations for _ types in tests

### DIFF
--- a/.github/workflows/ci-oldest-reqs.txt
+++ b/.github/workflows/ci-oldest-reqs.txt
@@ -1,5 +1,5 @@
 coverage==5.3.1
-numpy==1.19.0
+numpy==1.21.0
 pymongo==3.10.0
 pytest==6.2.1
 pytest-cov==2.10.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,13 @@ Changelog
 
 The **synced_collections** package follows `semantic versioning <https://semver.org/>`_.
 
+[1.0.1] -- 2024-xx-xx
+---------------------
+
+Fixed
++++++
+
+- Tests run with numpy 2.0.
 
 [1.0.0] -- 2023-05-17
 =====================

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -42,4 +42,9 @@ contributors:
     family-names: Mahapatra
     given-names: Onkar
     affiliation: "Cluster Innovation Centre, New Delhi"
+  -
+    family-names: Kerr
+    given-names: "Corwin B."
+    affiliation: "University of Michigan"
+    orcid: "https://orcid.org/0000-0003-0776-2596"
 ...

--- a/requirements/requirements-test-optional.txt
+++ b/requirements/requirements-test-optional.txt
@@ -1,4 +1,4 @@
-numpy==1.26.4
+numpy==2.0.0
 pymongo==4.6.3; implementation_name=='cpython'
 redis==5.0.3
 zarr==2.17.1; platform_system!='Windows'

--- a/tests/synced_collection_test.py
+++ b/tests/synced_collection_test.py
@@ -53,7 +53,6 @@ try:
         numpy.longdouble,
         numpy.float32,
         numpy.float64,
-        numpy.float64,
     )
 
     NUMPY_COMPLEX_TYPES: Tuple[Type, ...] = (
@@ -61,7 +60,6 @@ try:
         numpy.cdouble,
         numpy.clongdouble,
         numpy.complex64,
-        numpy.complex128,
         numpy.complex128,
     )
     NUMPY_SHAPES: Tuple[Any, ...] = (None, (1,), (2,), (2, 2))

--- a/tests/synced_collection_test.py
+++ b/tests/synced_collection_test.py
@@ -53,7 +53,7 @@ try:
         numpy.longdouble,
         numpy.float32,
         numpy.float64,
-        numpy.float_,
+        numpy.float64,
     )
 
     NUMPY_COMPLEX_TYPES: Tuple[Type, ...] = (
@@ -62,7 +62,7 @@ try:
         numpy.clongdouble,
         numpy.complex64,
         numpy.complex128,
-        numpy.complex_,
+        numpy.complex128,
     )
     NUMPY_SHAPES: Tuple[Any, ...] = (None, (1,), (2,), (2, 2))
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -79,12 +79,12 @@ class TestJSONFormatValidator:
     def test_numpy_data(self):
         data = numpy.random.rand(3, 4)
         json_format_validator(data)
-        json_format_validator(numpy.float_(3.14))
+        json_format_validator(numpy.float64(3.14))
         # numpy data as dict value
         json_format_validator({"test": data})
-        json_format_validator({"test": numpy.float_(1.0)})
+        json_format_validator({"test": numpy.float64(1.0)})
         # numpy data in list
-        json_format_validator([data, numpy.float_(1.0), 1, "test"])
+        json_format_validator([data, numpy.float64(1.0), 1, "test"])
 
     def test_invalid_data(self):
         class A:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

Makes tests pass for numpy 2.0. Tests still pass with 1.26 too.

Applies these changes to update `float_` and `complex_` types
https://numpy.org/doc/stable//numpy_2_0_migration_guide.html#changes-to-namespaces

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Prepare for numpy 2.0

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [X] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/synced_collections/blob/main/CONTRIBUTING.md).
- [X] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/synced_collections/blob/main/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/synced_collections/blob/main/contributors.yaml).
- [X] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/synced_collections/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
